### PR TITLE
Simplify various parts of code, open possibility for more request handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ cabal.sandbox.config
 cabal.config
 .stack-work
 stack.yaml
+dist-newstyle
 
 # =========================
 # Operating System Files
@@ -58,3 +59,7 @@ $RECYCLE.BIN/
 
 # Windows shortcuts
 *.lnk
+
+# TAG files, hasktags &c.
+TAGS
+tags

--- a/franz.cabal
+++ b/franz.cabal
@@ -36,7 +36,7 @@ library
     , bytestring
     , cereal
     , containers
-    , concurrent-resource-map
+    , concurrent-resource-map >=0.2 && <0.3
     , cpu
     , deepseq
     , directory

--- a/franz.cabal
+++ b/franz.cabal
@@ -35,7 +35,7 @@ library
     , bytestring
     , cereal
     , containers
-    , concurrent-resource-map >=0.2 && <0.3
+    , concurrent-resource-map ^>=0.2
     , cpu
     , deepseq
     , directory

--- a/franz.cabal
+++ b/franz.cabal
@@ -32,7 +32,6 @@ library
       src
   build-depends:
       base >=4.7 && <5
-    , async
     , bytestring
     , cereal
     , containers
@@ -49,6 +48,7 @@ library
     , retry
     , sendfile
     , stm
+    , stm-delay
     , transformers
     , unboxed-ref
     , vector

--- a/franz.cabal
+++ b/franz.cabal
@@ -32,6 +32,7 @@ library
       src
   build-depends:
       base >=4.7 && <5
+    , async
     , bytestring
     , cereal
     , containers
@@ -48,7 +49,6 @@ library
     , retry
     , sendfile
     , stm
-    , stm-delay
     , transformers
     , vector
     , unordered-containers

--- a/franz.cabal
+++ b/franz.cabal
@@ -50,6 +50,7 @@ library
     , sendfile
     , stm
     , transformers
+    , unboxed-ref
     , vector
     , unordered-containers
   default-language: Haskell2010

--- a/src/Database/Franz/Network.hs
+++ b/src/Database/Franz/Network.hs
@@ -221,10 +221,9 @@ fetch Connection{..} req cont = do
   withSharedResource connStates reqId
     (newTVarIO WaitingInstant)
     cleanupRequest $ \reqVar -> do
-    let allowDelayedResponse = True {- isRight onDelayed'e -}
     -- Send the user request.
     withMVar connSocket $ \sock -> SB.sendAll sock $ encode
-      $ RawRequest reqId req allowDelayedResponse
+      $ RawRequest reqId req
 
     let
       requestFinished = ClientError "request already finished"

--- a/src/Database/Franz/Network.hs
+++ b/src/Database/Franz/Network.hs
@@ -17,7 +17,6 @@ module Database.Franz.Network
   , SomeIndexMap
   , Contents
   , fetch
-  , fetchTraverse
   , fetchSimple
   , FranzException(..)) where
 
@@ -226,22 +225,6 @@ fetch Connection{..} req onInstant onDelayed'e = do
       -- If the response arrived, no need to send a clean request
       return $ when (IM.member reqId m)
         $ withMVar connSocket $ \sock -> SB.sendAll sock $ encode $ RawClean reqId
-
-
--- | Queries in traversable @t@ form an atomic request. The response will become
--- available once all the elements are available.
---
--- Generalisation to Traversable guarantees that the response preserves the
--- shape of the request.
-fetchTraverse
-  :: Traversable t
-  => Connection
-  -> t Query
-  -> (Contents -> IO r)
-  -> Either (IO r) (IO (Contents -> IO r))
-  -> IO (t r)
-fetchTraverse conn reqs onInstant onDelayed = forConcurrently reqs $ \req ->
-  fetch conn req onInstant onDelayed
 
 -- | Send a single query and wait for the result. If it timeouts, it returns an empty list.
 fetchSimple :: Connection

--- a/src/Database/Franz/Protocol.hs
+++ b/src/Database/Franz/Protocol.hs
@@ -61,10 +61,9 @@ instance Serialize RawRequest
 
 type ResponseId = Int
 
-data ResponseHeader = ResponseInstant !ResponseId
+data ResponseHeader = Response !ResponseId
     -- ^ response ID, number of streams; there are items satisfying the query
     | ResponseWait !ResponseId -- ^ response ID; requested elements are not available right now
-    | ResponseDelayed !ResponseId -- ^ response ID, number of streams; items are available
     | ResponseError !ResponseId !FranzException -- ^ something went wrong
     deriving (Show, Generic)
 instance Serialize ResponseHeader

--- a/src/Database/Franz/Protocol.hs
+++ b/src/Database/Franz/Protocol.hs
@@ -52,8 +52,11 @@ data Query = Query
   } deriving (Show, Generic)
 instance Serialize Query
 
-data RawRequest = RawRequest !ResponseId !Query
-    | RawClean !ResponseId deriving Generic
+type AllowDelayedResponse = Bool
+
+data RawRequest
+  = RawRequest !ResponseId !Query !AllowDelayedResponse
+  | RawClean !ResponseId deriving Generic
 instance Serialize RawRequest
 
 type ResponseId = Int

--- a/src/Database/Franz/Protocol.hs
+++ b/src/Database/Franz/Protocol.hs
@@ -52,10 +52,8 @@ data Query = Query
   } deriving (Show, Generic)
 instance Serialize Query
 
-type AllowDelayedResponse = Bool
-
 data RawRequest
-  = RawRequest !ResponseId !Query !AllowDelayedResponse
+  = RawRequest !ResponseId !Query
   | RawClean !ResponseId deriving Generic
 instance Serialize RawRequest
 

--- a/src/Database/Franz/Server.hs
+++ b/src/Database/Franz/Server.hs
@@ -42,7 +42,7 @@ respond :: FranzReader
 respond env refThreads path buf vConn = do
   recvConn <- readMVar vConn
   runGetRecv buf recvConn get >>= \case
-    Right (RawRequest reqId req allowDelayed) -> do
+    Right (RawRequest reqId req) -> do
       let pop result = do
             case result of
               Left ex | Just e <- fromException ex -> sendHeader $ ResponseError reqId e
@@ -53,7 +53,7 @@ respond env refThreads path buf vConn = do
           Left e -> sendHeader $ ResponseError reqId e
           Right (ready, offsets)
             | ready -> send (Response reqId) stream offsets
-            | allowDelayed -> do
+            | otherwise -> do
               tid <- flip forkFinally pop $ bracket_
                 (atomically $ addActivity stream)
                 (removeActivity stream) $ do

--- a/src/Database/Franz/Server.hs
+++ b/src/Database/Franz/Server.hs
@@ -52,7 +52,7 @@ respond env refThreads path buf vConn = do
         atomically (fmap Right query `catchSTM` (pure . Left)) >>= \case
           Left e -> sendHeader $ ResponseError reqId e
           Right (ready, offsets)
-            | ready -> send (ResponseInstant reqId) stream offsets
+            | ready -> send (Response reqId) stream offsets
             | allowDelayed -> do
               m <- readIORef refThreads
               when (IM.member reqId m) $ throwIO $ MalformedRequest "duplicate request ID"
@@ -64,7 +64,7 @@ respond env refThreads path buf vConn = do
                     (ready', offsets') <- query
                     check ready'
                     pure offsets'
-                  send (ResponseDelayed reqId) stream offsets'
+                  send (Response reqId) stream offsets'
               writeIORef refThreads $! IM.insert reqId tid m
             -- Response is not ready but the user indicated that they
             -- are not interested in waiting either. While we have no

--- a/src/Database/Franz/Server.hs
+++ b/src/Database/Franz/Server.hs
@@ -126,7 +126,7 @@ startServer Settings{..} = withFranzReader livePrefix $ \franzReader -> do
   bracket (S.socket (S.addrFamily addr) S.Stream (S.addrProtocol addr)) S.close $ \sock -> do
     S.setSocketOption sock S.ReuseAddr 1
     S.setSocketOption sock S.NoDelay 1
-    S.bind sock $ S.SockAddrInet (fromIntegral port) (S.tupleToHostAddress (0,0,0,0))
+    S.bind sock $ S.addrAddress addr
     S.listen sock S.maxListenQueue
     logServer ["Listening on", show port]
 


### PR DESCRIPTION
I think I managed to simplify the way various parts were written. I made small API changes, such as to `fetch` and removing `fetchTraverse`; especially the way `fetch` was written, it gave too much freedom to the user while not providing extra expressiveness while being too heavy-handed in exception handling.

I have pulled in `async` package for `race`, and maybe there are few more places we should be using it: I hope that's OK; these things are quite tricky to implement correctly in presence of exceptions.

Each individual comment should have relevant description, please have a look. If we don't like some changes, I'm of course open to discussion.