### PR TITLE
Update haskell.yml

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -1,6 +1,6 @@
 name: Haskell CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
Since recent changes have been made to Actions for the forked repository to prevent automatic CI execution. So, the `pull_request` should also be enabled.