### PR TITLE
Bump actions/cache from v1 to v2

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -15,7 +15,7 @@ jobs:
         cabal-version: '3.0'
 
     - name: cabal Cache
-      uses: actions/cache@v1
+      uses: actions/cache@v2
       env:
         cache-name: cache-cabal
       with:


### PR DESCRIPTION
We just released v2. That includes a lot of improvements.
https://github.com/actions/cache/releases/tag/v2.0.0